### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/wwwgamesensepub/85926823-5bbc-4a97-87aa-78e79db23598/1043a6c1-41d4-435f-8291-997110805037/_apis/work/boardbadge/f2ef5ef6-ce58-4b4a-bfbf-b8a7373f3069)](https://dev.azure.com/wwwgamesensepub/85926823-5bbc-4a97-87aa-78e79db23598/_boards/board/t/1043a6c1-41d4-435f-8291-997110805037/Microsoft.RequirementCategory)
 # gamesense.cloud


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/wwwgamesensepub/85926823-5bbc-4a97-87aa-78e79db23598/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.